### PR TITLE
Add definitions for readlink and fchown

### DIFF
--- a/sysdeps/unix/sysv/linux/ukl/fchown.c
+++ b/sysdeps/unix/sysv/linux/ukl/fchown.c
@@ -1,0 +1,34 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+int
+__fchown (int fd, uid_t owner, gid_t group)
+{
+  if (fd < 0)
+    {
+      __set_errno (EBADF);
+      return -1;
+    }
+  return INLINE_SYSCALL(fchown, 3, fd, owner, group);
+}
+libc_hidden_def (__fchown)
+
+strong_alias (__fchown, fchown)

--- a/sysdeps/unix/sysv/linux/ukl/readlink.c
+++ b/sysdeps/unix/sysv/linux/ukl/readlink.c
@@ -1,0 +1,34 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+ssize_t
+__readlink(const char *pathname, char *buf, size_t bufsiz)
+{
+  if (buf == NULL || pathname == NULL)
+    {
+       __set_errno (EINVAL);
+       return -1;
+    }
+  return INLINE_SYSCALL(readlink, 3, pathname, buf, bufsiz);
+}
+libc_hidden_def (__readlink)
+
+strong_alias (__readlink, readlink)


### PR DESCRIPTION
These functions are needed for dnsmasq so add wrappers for them to the
ukl linux variant.

Signed-off-by: Eric B Munson <munsoner@bu.edu>