### PR TITLE
Add more missing syscalls

### DIFF
--- a/sysdeps/unix/sysv/linux/Makefile
+++ b/sysdeps/unix/sysv/linux/Makefile
@@ -62,7 +62,8 @@ sysdep_routines += adjtimex clone umount umount2 readahead \
 		   personality epoll_wait tee vmsplice splice \
 		   open_by_handle_at mlock2 pkey_mprotect pkey_set pkey_get \
 		   epoll_create epoll_create1 epoll_ctl \
-		   timerfd_create prctl timerfd_settime
+		   timerfd_create prctl timerfd_settime capget capset inotify_init \
+		   inotify_add_watch
 
 CFLAGS-gethostid.c = -fexceptions
 CFLAGS-tee.c = -fexceptions -fasynchronous-unwind-tables

--- a/sysdeps/unix/sysv/linux/ukl/capget.c
+++ b/sysdeps/unix/sysv/linux/ukl/capget.c
@@ -1,0 +1,30 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+#include <linux/capability.h>
+
+int
+__capget (cap_user_header_t hdrp, cap_user_data_t datap)
+{
+  return INLINE_SYSCALL(capget, 2, hdrp, datap);
+}
+libc_hidden_def (__capget)
+
+strong_alias (__capget, capget)

--- a/sysdeps/unix/sysv/linux/ukl/capset.c
+++ b/sysdeps/unix/sysv/linux/ukl/capset.c
@@ -1,0 +1,30 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+#include <linux/capability.h>
+
+int
+__capset (cap_user_header_t hdrp, const	cap_user_data_t datap)
+{
+  return INLINE_SYSCALL(capset, 2, hdrp, datap);
+}
+libc_hidden_def (__capset)
+
+strong_alias (__capset, capset)

--- a/sysdeps/unix/sysv/linux/ukl/inotify_add_watch.c
+++ b/sysdeps/unix/sysv/linux/ukl/inotify_add_watch.c
@@ -1,0 +1,35 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+#include <sys/inotify.h>
+
+int
+__inotify_add_watch (int fd, const char *pathname, uint32_t mask)
+{
+  if (fd < 0)
+    {
+      __set_errno (EBADF);
+      return -1;
+    }
+  return INLINE_SYSCALL(inotify_add_watch, 3, fd, pathname, mask);
+}
+libc_hidden_def (__inotify_add_watch)
+
+strong_alias (__inotify_add_watch, inotify_add_watch)

--- a/sysdeps/unix/sysv/linux/ukl/inotify_init.c
+++ b/sysdeps/unix/sysv/linux/ukl/inotify_init.c
@@ -1,0 +1,39 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+#include <sys/inotify.h>
+
+int
+__inotify_init (void)
+{
+  return INLINE_SYSCALL(inotify_init, 0);
+}
+libc_hidden_def (__inotify_init)
+
+strong_alias (__inotify_init, inotify_init)
+
+int
+__inotify_init1 (int flags)
+{
+  return INLINE_SYSCALL(inotify_init1, 1, flags);
+}
+libc_hidden_def (__inotify_init1)
+
+strong_alias (__inotify_init1, inotify_init1)


### PR DESCRIPTION
catget, capset, inotify_add_watch, and the inotify_init functions are
all linux specific. Add them in support of dnsmasq.

Signed-off-by: Eric B Munson <munsoner@bu.edu>