### PR TITLE
Add Missing system calls for postgres

### DIFF
--- a/sysdeps/unix/sysv/linux/Makefile
+++ b/sysdeps/unix/sysv/linux/Makefile
@@ -63,7 +63,7 @@ sysdep_routines += adjtimex clone umount umount2 readahead \
 		   open_by_handle_at mlock2 pkey_mprotect pkey_set pkey_get \
 		   epoll_create epoll_create1 epoll_ctl \
 		   timerfd_create prctl timerfd_settime capget capset inotify_init \
-		   inotify_add_watch
+		   inotify_add_watch chown symlink rmdir syncfs
 
 CFLAGS-gethostid.c = -fexceptions
 CFLAGS-tee.c = -fexceptions -fasynchronous-unwind-tables

--- a/sysdeps/unix/sysv/linux/ukl/chown.c
+++ b/sysdeps/unix/sysv/linux/ukl/chown.c
@@ -1,0 +1,29 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+int
+__chown(const char *pathname, uid_t owner, gid_t group)
+{
+	return INLINE_SYSCALL(chown, 3, pathname, owner, group);
+}
+libc_hidden_def (__chown)
+
+strong_alias (__chown, chown)

--- a/sysdeps/unix/sysv/linux/ukl/mq_setattr.c
+++ b/sysdeps/unix/sysv/linux/ukl/mq_setattr.c
@@ -1,0 +1,30 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <mqueue.h>
+#include <stddef.h>
+#include <sysdep.h>
+
+int
+__mq_setattr(mqd_t mqdes, const struct mq_attr *newattr, struct mq_attr *oldattr)
+{
+	return INLINE_SYSCALL(mq_getsetattr, 3, mqdes, newattr, oldattr);
+}
+libc_hidden_def (__mq_setattr)
+
+strong_alias (__mq_setattr, mq_setattr)

--- a/sysdeps/unix/sysv/linux/ukl/rmdir.c
+++ b/sysdeps/unix/sysv/linux/ukl/rmdir.c
@@ -1,0 +1,29 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+int
+__rmdir(const char *pathname)
+{
+	return INLINE_SYSCALL(rmdir, 1, pathname);
+}
+libc_hidden_def (__rmdir)
+
+strong_alias (__rmdir, rmdir)

--- a/sysdeps/unix/sysv/linux/ukl/setitimer.c
+++ b/sysdeps/unix/sysv/linux/ukl/setitimer.c
@@ -1,0 +1,29 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+int
+__setitimer(enum __itimer_which which, const struct itimerval *new, struct itimerval *old)
+{
+	return INLINE_SYSCALL(setitimer, 3, which, new, old);
+}
+libc_hidden_def (__setitimer)
+
+strong_alias (__setitimer, setitimer)

--- a/sysdeps/unix/sysv/linux/ukl/symlink.c
+++ b/sysdeps/unix/sysv/linux/ukl/symlink.c
@@ -1,0 +1,29 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+int
+__symlink(const char *target, const char *linkpath)
+{
+	return INLINE_SYSCALL(symlink, 2, target, linkpath);
+}
+libc_hidden_def (__symlink)
+
+strong_alias (__symlink, symlink)

--- a/sysdeps/unix/sysv/linux/ukl/syncfs.c
+++ b/sysdeps/unix/sysv/linux/ukl/syncfs.c
@@ -1,0 +1,29 @@
+/* Copyright (C) 1991-2020 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <unistd.h>
+#include <sysdep.h>
+
+int
+__syncfs(int fd)
+{
+	return INLINE_SYSCALL(syncfs, 1, fd);
+}
+libc_hidden_def (__syncfs)
+
+strong_alias (__syncfs, syncfs)


### PR DESCRIPTION
Adding implementations for chown, fchown, mq_setattr, rmdir, setitimer,
symlink, and syncfs.

Signed-off-by: Eric B Munson <munsoner@bu.edu>